### PR TITLE
ci: pin feature build to stack pipeline branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,4 @@
-@Library("shared-jenkins-pipelines") _
-springBootDockerCiPipelineNoIT()
+@Library("shared-jenkins-pipelines@feat/sentinel-backcompat") _
+springBootDockerCiPipelineNoIT(
+    runProductionDeploy: false
+)


### PR DESCRIPTION
## Summary
- pin the feature-branch Jenkinsfile to `shared-jenkins-pipelines@feat/sentinel-backcompat`
- disable production deploys for this validation branch so it can be used to build image tags for the new stack migration safely
- keep the change isolated to the feature branch used for issue #77 validation

#77